### PR TITLE
Update to support common shield

### DIFF
--- a/app/assets/pages/shields/shield-code-edit.html
+++ b/app/assets/pages/shields/shield-code-edit.html
@@ -24,13 +24,14 @@
             </div>
             <div class="col-sm-6">
               <div class="form-group">
-                <label for="codeFile">Shield Sab File</label>
-                <input files-input type="file" class="form-control" id="codeFile"
-                       ng-model="shieldCodeEditCtrlVm.shieldCode.codeFile">
+                <label for="version">Shield Version</label>
+                <input type="text" class="form-control" id="version"
+                       ng-model="shieldCodeEditCtrlVm.shieldCode.version">
               </div>
             </div>
             <div class="col-sm-6">
               <div class="form-group">
+                <label>Implementation</label>
                 <ui-select ng-model="shieldCodeEditCtrlVm.shieldCode.commonShieldId">
                   <ui-select-match placeholder="Select Common Shield">
                     {{$select.selected.name}} <br> <small>{{$select.selected.description}}</small>

--- a/app/assets/pages/shields/shield-edit.html
+++ b/app/assets/pages/shields/shield-edit.html
@@ -82,16 +82,24 @@
             <th class="table-id">#</th>
             <th>Name</th>
             <th>Description</th>
+            <th>Implementation</th>
+            <th>Version</th>
             <th>Enabled</th>
             <th>Actions</th>
           </tr>
-          <tr ng-repeat="shieldCode in shieldEditCtrlVm.shieldcodes" class="editable-tr-wrap">
+          <tr ng-repeat="shieldCode in shieldEditCtrlVm.shieldcodes">
             <td class="table-id">{{$index + 1}}</td>
             <td>
               <span>{{shieldCode.name}}</span>
             </td>
             <td>
               <span>{{shieldCode.description}}</span>
+            </td>
+            <td>
+              <span>{{ shieldEditCtrlVm.getCommonShieldName( shieldCode.commonShieldId) }}</span>
+            </td>
+            <td>
+              <span>{{shieldCode.version}}</span>
             </td>
             <td>
               <span>{{shieldCode.enabled}}</span>

--- a/app/assets/pages/shields/shieldCodeEditCtrl.js
+++ b/app/assets/pages/shields/shieldCodeEditCtrl.js
@@ -43,10 +43,11 @@ function ShieldCodeEditCtrl($state, $stateParams, toastr, uuid4,
         description: vm.shieldCode.description,
         commonShieldId: vm.shieldCode.commonShieldId,
         jobOptions: vm.shieldCode.jobOptions,
-        enabled: vm.shieldCode.enabled
+        enabled: vm.shieldCode.enabled,
+        version: vm.shieldCode.version
       };
       promise = shieldCodeService.updatePartial($stateParams.shieldCodeId, partial)
-    } 
+    }
     promise.then(function(resp) {
       _.merge(vm.shieldCode, resp.data);
       vm.saving = false;

--- a/app/assets/pages/shields/shieldEditCtrl.js
+++ b/app/assets/pages/shields/shieldEditCtrl.js
@@ -7,16 +7,22 @@
 
 angular.module('BlurAdmin.pages.shields').controller('ShieldEditCtrl', ShieldEditCtrl);
 
-function ShieldEditCtrl($state, $stateParams, $uibModal, toastr, shieldService, shieldCodeService, actionService) {
+function ShieldEditCtrl($state, $stateParams, $uibModal, toastr, shieldService, shieldCodeService, actionService, commonShieldService) {
   var vm = this;
-  vm.shield = { };
+  vm.shield = {};
   vm.shieldcodes = [];
+  vm.commonShieldsMap = {};
   vm.saving = false;
 
   actionService.findAll().then(function (resp) {
     vm.actions = resp.data.items;
   });
 
+  commonShieldService.findAll().then(function (resp) {
+    _.each(resp.data.items, function(commonShield) {
+      vm.commonShieldsMap[commonShield._id] = commonShield;
+    });
+  });
 
   if($stateParams.shieldId && $stateParams.shieldId !== 'new') {
     shieldCodeService.findAll({shieldId: $stateParams.shieldId}).then(function (resp) {
@@ -36,6 +42,11 @@ function ShieldEditCtrl($state, $stateParams, $uibModal, toastr, shieldService, 
       sensorType: "",
       shieldParameters: []
     };
+  }
+
+  vm.getCommonShieldName = function(commonShieldId) {
+      var cs = vm.commonShieldsMap[commonShieldId];
+      return cs ? cs.name : '';
   }
 
   vm.saveShield = function() {

--- a/app/scripts/services/ShieldCodeService.js
+++ b/app/scripts/services/ShieldCodeService.js
@@ -3,32 +3,15 @@
 angular.module('BlurAdmin.services').factory('shieldCodeService', function(BaseService, $http) {
   var service = new BaseService('shield-codes');
   service.save = function (model) {
-    var hasFile = false;
-    var fd = new FormData();
-    for(var key in model) {
-      if (model.hasOwnProperty(key)) {
-        if (model[key] instanceof Object && !(model[key] instanceof File || model[key] instanceof FileReader)) {
-          fd.append(key, JSON.stringify(model[key]));
-          continue;
-        }
-        if (model[key] instanceof File || model[key] instanceof FileReader) {
-          hasFile = true;
-        }
-        fd.append(key, model[key]);
-      }
-    }
-    if(model._id) {
-      if (hasFile) {
-        return $http.put(this.apiUrl + model._id, fd, {headers: {'Content-Type': undefined}});
-      } else {
-        return $http.post(this.apiUrl + model._id, model);
-      }
+
+    // clone the model as jobOptions needs to be modified to be string
+    var modelToSend = JSON.parse(JSON.stringify(model));
+    modelToSend.jobOptions = JSON.stringify(modelToSend.jobOptions);
+
+    if(modelToSend._id) {
+      return $http.put(this.apiUrl + modelToSend._id, modelToSend);
     } else {
-      if (hasFile) {
-        return $http.post(this.apiUrl, fd, {headers: {'Content-Type': undefined}});
-      } else {
-        return $http.post(this.apiUrl, model);
-      }
+      return $http.post(this.apiUrl, modelToSend);
     }
   };
   return service;


### PR DESCRIPTION
Changes:
1. remove SAB file input from shield code page
2. display common shield name and version in the shield code list
3. switch from FormData to JSON when creating/updating shields through the API

Outstanding issue: the API expects the jobOptions to be a string. Until that is resolved the jobOptions is stringified when sent to the backend.

Shield Code List
![shield-edit](https://user-images.githubusercontent.com/10561287/39628454-d07ec7f8-4fb1-11e8-89ab-037c76392708.png)

Shield Editor
![image](https://user-images.githubusercontent.com/10561287/39628602-3ae32dbe-4fb2-11e8-92c1-21663f40e09a.png)

